### PR TITLE
Support for tiktok's /t/ URLs.

### DIFF
--- a/src/modules/services/_config.json
+++ b/src/modules/services/_config.json
@@ -62,7 +62,7 @@
         "enabled": false
     },
     "tiktok": {
-        "patterns": [":user/video/:postId", ":id"],
+        "patterns": [":user/video/:postId", ":id", "t/:id"],
         "enabled": true
     },
     "douyin": {


### PR DESCRIPTION
When sharing from TikTok via the app, some URLs show up as:

https://www.tiktok.com/t/:ID/?k=1, similar to vm.tiktok.com/:ID urls, cobalt doesn't recognize the first style of links.
This should fix that, I think.

Edit: I've tested this with multiple videos, it works.