### PR TITLE
fix tiktok downloads

### DIFF
--- a/src/modules/servicesConfig.json
+++ b/src/modules/servicesConfig.json
@@ -64,7 +64,7 @@
         "tiktok": {
             "patterns": [":user/video/:postId", ":id", "t/:id"],
             "audioFormats": ["best", "m4a", "mp3"],
-            "enabled": false
+            "enabled": true
         },
         "douyin": {
             "patterns": ["video/:postId", ":id"],


### PR DESCRIPTION
this endpoint seems to work, not sure if they disabled the other one but this returns the same info (from what i could tell?). The `userAgent` needs to be a mobile one, and `version_code` and `device_type` are required, although their values doesn't affect anything. 

fyi, there's another endpoint `queryBatchAweme`, `/aweme/v1/multi/aweme/detail/?aweme_ids=[]`, which returns the same info. And maybe the original one ('queryAweme') still works too (both of them are still there on the app), but didn't wanna dig anymore since both of these work the same.

`curl 'https://api.tiktokv.com/aweme/v1/multi/aweme/detail/?aweme_ids=%5B7145492359399197998%5D&version_code=26.2.0&app_name=musical_ly&channel=App&device_id=null&os_version=14.4.2&device_platform=iphone&device_type=iPhone9' -H 'user-agent: TikTok 26.2.0 rv:262018 (iPhone; iOS 14.4.2; en_US) Cronet'` 

