### PR TITLE
add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:18-bullseye-slim
+WORKDIR /app
+COPY package*.json ./
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+RUN npm install
+COPY . .
+EXPOSE 9000
+CMD [ "node", "src/cobalt" ]
+


### PR DESCRIPTION
adds a dockerfile, so we can stuff more things in containers

uses node:18-bullseye-slim because most recent node lts, alpine breaks it so gotta use debian, slim so the resulting image is like 470MB instead of over a gig.

cobalt doesn't quite function like an app you'd normally dockerize since it requires the .env to exist and won't just take a pile of env variables, but that could be fixed pretty ez

for now just doing a bind mount to the already configured `.env` works 