### PR TITLE
feat(setup): add cors option to setup script

### DIFF
--- a/src/modules/setup.js
+++ b/src/modules/setup.js
@@ -42,6 +42,12 @@ rl.question(q, r1 => {
     rl.question(q, r2 => {
         if (r2) ob['port'] = r2
         if (!r1 && r2) ob['selfURL'] = `http://localhost:${r2}/`
-        final()
+
+        console.log(Bright("\nIf you would like to enable CORS, enter 'y'. (y)\nCORS allows other websites and extensions to use your instance's API."))
+
+        rl.question(q, r3 => {
+            if (r3.toLowerCase() !== 'y') ob['cors'] = '0'
+            final()
+        })
     });
 })

--- a/src/modules/setup.js
+++ b/src/modules/setup.js
@@ -43,7 +43,7 @@ rl.question(q, r1 => {
         if (r2) ob['port'] = r2
         if (!r1 && r2) ob['selfURL'] = `http://localhost:${r2}/`
 
-        console.log(Bright("\nIf you would like to enable CORS, enter 'y'. (y)\nCORS allows other websites and extensions to use your instance's API."))
+        console.log(Bright("\nWould you like to enable CORS? It allows other websites and extensions to use your instance's API.\n y/n (n)"))
 
         rl.question(q, r3 => {
             if (r3.toLowerCase() !== 'y') ob['cors'] = '0'


### PR DESCRIPTION
# Summary

- When running the setup script, allow the user to enable CORS for their instance. It is disabled by default.

# Preview

![image](https://user-images.githubusercontent.com/78003700/230754926-377ea662-79d4-46be-aaf2-f07a1bd8ad0f.png)

![image](https://user-images.githubusercontent.com/78003700/230754928-a763c67a-f4e9-4da8-93a0-833002f82977.png)
