### PR TITLE
allow url loading via query param without `u=`

### DIFF
--- a/src/front/cobalt.js
+++ b/src/front/cobalt.js
@@ -432,7 +432,7 @@ window.onload = () => {
     eid("url-input-area").value = "";
     notificationCheck();
     if (isIOS) sSet("downloadPopup", "true");
-    let urlQuery = new URLSearchParams(window.location.search).get("u");
+    let urlQuery = new URLSearchParams(window.location.search).get("u") || window.location.search.substring(1);
     if (urlQuery !== null && regex.test(urlQuery)) {
         eid("url-input-area").value = urlQuery;
         button();


### PR DESCRIPTION
for example https://co.wukko.me/?u=https://www.reddit.com/r/196/comments/12yeg91/rule/ worked before, but https://co.wukko.me/?https://www.reddit.com/r/196/comments/12yeg91/rule/ didnt load the url. this change checks the search string without query params if the query param u isn't found, allowing the 2nd url to work which would be pretty cool and poggers in my humble opinion. and i would rather make a whole ass pull request than type two more letters to download a video of a chinchilla