### PR TITLE
Automatic build with github actions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,20 @@
+name: Docker Image CI
+on:
+  push:
+    tags:
+      - "*"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: 'Login to GitHub Container Registry'
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{github.actor}}
+        password: ${{secrets.GITHUB_TOKEN}}
+    - name: Build the Docker image
+      run: "docker build . --file Dockerfile --tag ghcr.io/${{ github.actor }}/cobalt:${{  github.ref_name }}"
+    - name: Push docker image
+      run: "docker push ghcr.io/${{ github.actor }}/cobalt:${{ github.ref_name }}"


### PR DESCRIPTION
This adds a simple github action which automatically builds the docker image on new tags. I think this is very helpful for easy deployment.
If you think that this workflow could exceed the free minutes, I can instead try to build it on my own CI-Server:
https://ci.cat-enby.club
But I thought running it with github actions directly is the most simple approach.