### PR TITLE
Resolve bilibili mobile `b23.tv` short links to full bilibili URL

### DIFF
--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -31,6 +31,14 @@ export async function getJSON(originalURL, lang, obj) {
                     url = url.replace(url.split('/')[5], '')
                 }
                 break;
+            case "b23":
+                const shortUrlId = new URL(url).pathname.split("/")[1];
+                if (!shortUrlId) {
+                    return apiJSON(0, { t: errorUnsupported(lang) });
+                }
+
+                host = "bilibili";
+                url = await fetch(`https://b23.tv/${shortUrlId}`).then(res => res.url);
         }
         if (!(host && host.length < 20 && host in patterns && patterns[host]["enabled"])) return apiJSON(0, { t: errorUnsupported(lang) });
 

--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -39,6 +39,7 @@ export async function getJSON(originalURL, lang, obj) {
 
                 host = "bilibili";
                 url = await fetch(`https://b23.tv/${shortUrlId}`).then(res => res.url);
+                break;
         }
         if (!(host && host.length < 20 && host in patterns && patterns[host]["enabled"])) return apiJSON(0, { t: errorUnsupported(lang) });
 


### PR DESCRIPTION
This PR allows a user to submit a `b23.tv` shortlink, which looks like this: `https://b23.tv/lbMyOI9`. Bilibili gives you links in this format when you copy a video URL on the mobile app (not on the website afaik). Unlike `youtu.be`, the ID following `b23.tv/` isn't the same as the ID in the `bilibili.com/video/:id` URL, so it's necessary to follow the link to resolve the redirect. The drawback is that this causes an additional request on the backend for b23.tv URLs which might be undesirable to add to cobalt.

Thanks in advance for your consideration, cobalt is super useful to me and I appreciate the effort :)