### PR TITLE
Use Alpine in dockerfile, drop ffmpeg-static

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM node:18-bullseye-slim
-WORKDIR /app
+FROM node:18-alpine
 
-RUN apt-get update
-RUN apt-get install -y git
-RUN rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache git ffmpeg
+
+WORKDIR /app
+RUN chown node:node /app
+USER node
 
 COPY package*.json ./
 RUN npm install
 
-RUN git clone -n https://github.com/wukko/cobalt.git --depth 1 && mv cobalt/.git ./ && rm -rf cobalt
+COPY --chown=node . .
 
-COPY . .
 EXPOSE 9000
 CMD [ "node", "src/cobalt" ]

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
         "esbuild": "^0.14.51",
         "express": "^4.18.1",
         "express-rate-limit": "^6.3.0",
-        "ffmpeg-static": "^5.1.0",
         "got": "^12.1.0",
         "nanoid": "^4.0.2",
         "node-cache": "^5.1.2",

--- a/src/modules/stream/types.js
+++ b/src/modules/stream/types.js
@@ -1,5 +1,4 @@
 import { spawn } from "child_process";
-import ffmpeg from "ffmpeg-static";
 import got from "got";
 import { ffmpegArgs, genericUserAgent } from "../config.js";
 import { getThreads, metadataManager, msToTime } from "../sub/utils.js";
@@ -46,7 +45,7 @@ export function streamLiveRender(streamInfo, res) {
         args = args.concat(ffmpegArgs[format])
         if (streamInfo.time) args.push('-t', msToTime(streamInfo.time));
         args.push('-f', format, 'pipe:4');
-        let ffmpegProcess = spawn(ffmpeg, args, {
+        let ffmpegProcess = spawn('ffmpeg', args, {
             windowsHide: true,
             stdio: [
                 'inherit', 'inherit', 'inherit',
@@ -114,7 +113,7 @@ export function streamAudioOnly(streamInfo, res) {
         if (ffmpegArgs[streamInfo.audioFormat]) args = args.concat(ffmpegArgs[streamInfo.audioFormat]);
         args.push('-f', streamInfo.audioFormat === "m4a" ? "ipod" : streamInfo.audioFormat, 'pipe:3');
 
-        const ffmpegProcess = spawn(ffmpeg, args, {
+        const ffmpegProcess = spawn('ffmpeg', args, {
             windowsHide: true,
             stdio: [
                 'inherit', 'inherit', 'inherit',
@@ -150,7 +149,7 @@ export function streamVideoOnly(streamInfo, res) {
         if (streamInfo.service === "vimeo") args.push('-bsf:a', 'aac_adtstoasc');
         if (format === "mp4") args.push('-movflags', 'faststart+frag_keyframe+empty_moov');
         args.push('-f', format, 'pipe:3');
-        const ffmpegProcess = spawn(ffmpeg, args, {
+        const ffmpegProcess = spawn('ffmpeg', args, {
             windowsHide: true,
             stdio: [
                 'inherit', 'inherit', 'inherit',


### PR DESCRIPTION
few things:
- Drops `ffmpeg-static` npm package and instead requires `ffmpeg` to be installed when ran standalone
- Docker image is now based on Alpine Linux instead of Debian and is 171MB lighter*
- Docker image no longer runs under the root user but instead the `node` user

\* could probably bring it down even more by somehow removing useless ffmpeg dependencies such as `sdl2` - compiling it in-container instead of pulling from repo?

seems to work but probably needs more testing idk