### PR TITLE
Set `tty` to true for containers

### DIFF
--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -5,6 +5,7 @@ services:
         build: .
         restart: unless-stopped
         container_name: cobalt-api
+        tty: true
         ports:
             - 9000:9000/tcp
         environment:
@@ -15,6 +16,7 @@ services:
         build: .
         restart: unless-stopped
         container_name: cobalt-web
+        tty: true
         ports:
             - 9000:9000/tcp
         environment:


### PR DESCRIPTION
For some reason, using `docker-compose up -d` doesn't allow my containers to run detached. They exist when my ssh session closes. Setting `tty` to `true` fixes this. It's probably something with my machine, but might help with others.