### PR TITLE
api: proper rate limiting (including limiting ipv6 by prefix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "express-rate-limit": "^6.3.0",
         "ffmpeg-static": "^5.1.0",
         "hls-parser": "^0.10.7",
+        "ipaddr.js": "2.1.0",
         "nanoid": "^4.0.2",
         "node-cache": "^5.1.2",
         "psl": "1.9.0",

--- a/src/core/api.js
+++ b/src/core/api.js
@@ -24,7 +24,7 @@ export function runAPI(express, app, gitCommit, gitBranch, __dirname) {
         max: 20,
         standardHeaders: true,
         legacyHeaders: false,
-        keyGenerator: (req, res) => sha256(getIP(req), ipSalt),
+        keyGenerator: req => sha256(getIP(req), ipSalt),
         handler: (req, res, next, opt) => {
             return res.status(429).json({
                 "status": "rate-limit",
@@ -37,7 +37,7 @@ export function runAPI(express, app, gitCommit, gitBranch, __dirname) {
         max: 25,
         standardHeaders: true,
         legacyHeaders: false,
-        keyGenerator: (req, res) => sha256(getIP(req), ipSalt),
+        keyGenerator: req => sha256(getIP(req), ipSalt),
         handler: (req, res, next, opt) => {
             return res.status(429).json({
                 "status": "rate-limit",
@@ -48,6 +48,8 @@ export function runAPI(express, app, gitCommit, gitBranch, __dirname) {
     
     const startTime = new Date();
     const startTimestamp = Math.floor(startTime.getTime());
+
+    app.set('trust proxy', ['loopback', 'uniquelocal']);
 
     app.use('/api/:type', cors(corsConfig));
     app.use('/api/json', apiLimiter);

--- a/src/modules/sub/utils.js
+++ b/src/modules/sub/utils.js
@@ -1,5 +1,6 @@
 import { normalizeURL } from "../processing/url.js";
 import { createStream } from "../stream/manage.js";
+import ipaddr from "ipaddr.js";
 
 const apiVar = {
     allowed: {
@@ -111,7 +112,16 @@ export function checkJSONPost(obj) {
     }
 }
 export function getIP(req) {
-    return req.header('cf-connecting-ip') ? req.header('cf-connecting-ip') : req.ip;
+    const strippedIP = req.ip.replace(/^::ffff:/, '');
+    const ip = ipaddr.parse(strippedIP);
+    if (ip.kind() === 'ipv4')
+        return strippedIP;
+
+    const PREFIX = 56;
+    const v6Bytes = ip.toByteArray();
+          v6Bytes.fill(0, PREFIX / 8);
+
+    return ipaddr.fromByteArray(v6Bytes).toString();
 }
 export function cleanHTML(html) {
     let clean = html.replace(/ {4}/g, '');

--- a/src/modules/sub/utils.js
+++ b/src/modules/sub/utils.js
@@ -114,12 +114,13 @@ export function checkJSONPost(obj) {
 export function getIP(req) {
     const strippedIP = req.ip.replace(/^::ffff:/, '');
     const ip = ipaddr.parse(strippedIP);
-    if (ip.kind() === 'ipv4')
+    if (ip.kind() === 'ipv4') {
         return strippedIP;
+    }
 
-    const PREFIX = 56;
+    const prefix = 56;
     const v6Bytes = ip.toByteArray();
-          v6Bytes.fill(0, PREFIX / 8);
+          v6Bytes.fill(0, prefix / 8);
 
     return ipaddr.fromByteArray(v6Bytes).toString();
 }


### PR DESCRIPTION
allows for more versatile configurations that do not necessarily have to use cloudflare

works with:
 + accessing port 9000 directly -> req.ip is actual ip, xff is ignored
 + no cloudflare, reverse proxy (caddy: default config, nginx: needs `add_header`)
 + cloudflare (nginx: default config*, caddy: needs `trusted_proxies`)

\* if the server is incorrectly setup and accessible not just via cloudflare but directly (no ip allowlist and/or no origin certificate), user can set the xff header to whatever they want (but the current version of cobalt also has this issue lol)

(note: by "default config" i mean the bare minimum to proxy cobalt through that particular webserver)

also ratelimits IPv6 addresses by prefix instead of individual addresses
i set it at /56, which should not be too strict (yet allows a /48 holder to make 256 as many requests instead of 2^80 as many requests which is "better" i guess), change if needed