### PR TITLE
fix soundcloud downloads when requested format is `best`

### DIFF
--- a/src/modules/processing/matchActionDecider.js
+++ b/src/modules/processing/matchActionDecider.js
@@ -126,7 +126,12 @@ export default function(r, host, audioFormat, isAudioOnly, lang, isAudioMuted, d
             }
             if ((audioFormat === "best" && services[host]["bestAudio"]) || (services[host]["bestAudio"] && (audioFormat === services[host]["bestAudio"]))) {
                 audioFormat = services[host]["bestAudio"];
-                processType = "bridge"
+                if (host === "soundcloud") {
+                    processType = "render"
+                    copy = true
+                } else {
+                    processType = "bridge"
+                }
             } else if (audioFormat === "best") {
                 audioFormat = "m4a";
                 copy = true;

--- a/src/modules/processing/servicesConfig.json
+++ b/src/modules/processing/servicesConfig.json
@@ -49,7 +49,7 @@
         },
         "soundcloud": {
             "patterns": [":author/:song/s-:accessKey", ":author/:song", ":shortLink"],
-            "bestAudio": "none",
+            "bestAudio": "opus",
             "enabled": true
         },
         "instagram": {


### PR DESCRIPTION
cobalt currently serves a m3u file for soundcloud downloads with `audioQuality` set to best which is obviously not intended
this fixes it kthx