### PR TITLE
youtube: unify quality matching, slight cleanup

### DIFF
--- a/src/modules/processing/services/youtube.js
+++ b/src/modules/processing/services/youtube.js
@@ -40,22 +40,22 @@ export default async function(o) {
     if (info.basic_info.is_live) return { error: 'ErrorLiveVideo' };
 
     let bestQuality, hasAudio, adaptive_formats = info.streaming_data.adaptive_formats.filter(e => 
-        e["mime_type"].includes(c[o.format].codec) || e["mime_type"].includes(c[o.format].aCodec)
+        e.mime_type.includes(c[o.format].codec) || e.mime_type.includes(c[o.format].aCodec)
     ).sort((a, b) => Number(b.bitrate) - Number(a.bitrate));
 
-    bestQuality = adaptive_formats.find(i => i["has_video"]);
-    hasAudio = adaptive_formats.find(i => i["has_audio"]);
+    bestQuality = adaptive_formats.find(i => i.has_video);
+    hasAudio = adaptive_formats.find(i => i.has_audio);
 
     if (bestQuality) bestQuality = qual(bestQuality);
     if (!bestQuality && !o.isAudioOnly || !hasAudio) return { error: 'ErrorYTTryOtherCodec' };
     if (info.basic_info.duration > maxVideoDuration / 1000) return { error: ['ErrorLengthLimit', maxVideoDuration / 60000] };
 
-    let checkBestAudio = (i) => (i["has_audio"] && !i["has_video"]),
-        audio = adaptive_formats.find(i => checkBestAudio(i) && !i["is_dubbed"]);
+    let checkBestAudio = (i) => (i.has_audio && !i.has_video),
+        audio = adaptive_formats.find(i => checkBestAudio(i) && !i.is_dubbed);
 
     if (o.dubLang) {
         let dubbedAudio = adaptive_formats.find(i =>
-            checkBestAudio(i) && i["language"] === o.dubLang && i["audio_track"] && !i["audio_track"].audio_is_default
+            checkBestAudio(i) && i.language === o.dubLang && i.audio_track && !i.audio_track.audio_is_default
         );
         if (dubbedAudio) {
             audio = dubbedAudio;
@@ -114,8 +114,10 @@ export default async function(o) {
         filenameAttributes.extension = c[o.format].container;
         filenameAttributes.youtubeFormat = o.format;
         return {
-            type, urls,
-            filenameAttributes, fileMetadata
+            type,
+            urls,
+            filenameAttributes, 
+            fileMetadata
         }
     }
 

--- a/src/modules/processing/services/youtube.js
+++ b/src/modules/processing/services/youtube.js
@@ -90,12 +90,12 @@ export default async function(o) {
         filenameAttributes: filenameAttributes,
         fileMetadata: fileMetadata
     }
-    let checkSingle = (i) => ((qual(i) === quality || qual(i) === bestQuality) && i["mime_type"].includes(c[o.format].codec)),
-        checkBestVideo = (i) => (i["has_video"] && !i["has_audio"] && qual(i) === bestQuality),
-        checkRightVideo = (i) => (i["has_video"] && !i["has_audio"] && qual(i) === quality);
+    const matchingQuality = Number(quality) > Number(bestQuality) ? bestQuality : quality,
+        checkSingle = i => qual(i) === matchingQuality && i.mime_type.includes(c[o.format].codec),
+        checkRender = i => i.has_video && !i.has_audio && qual(i) === matchingQuality;
 
     if (!o.isAudioOnly && !o.isAudioMuted && o.format === 'h264') {
-        let single = info.streaming_data.formats.find(i => checkSingle(i));
+        let single = info.streaming_data.formats.find(checkSingle);
         if (single) {
             filenameAttributes.qualityLabel = single.quality_label;
             filenameAttributes.resolution = `${single.width}x${single.height}`;
@@ -110,7 +110,7 @@ export default async function(o) {
         }
     }
 
-    let video = adaptive_formats.find(i => ((Number(quality) > Number(bestQuality)) ? checkBestVideo(i) : checkRightVideo(i)));
+    let video = adaptive_formats.find(checkRender);
     if (video && audio) {
         filenameAttributes.qualityLabel = video.quality_label;
         filenameAttributes.resolution = `${video.width}x${video.height}`;


### PR DESCRIPTION
fixes https://discord.com/channels/1049706293700591677/1049740124231061555/1163870548854579322:
> It appears that some YouTube videos (like this one https://youtube.com/watch?v=uuAgccyZVJ8) are handled a bit weirdly by the quality settings, in particular this one cannot be downloaded in 144p or 240p and if these are provided as parameters to the API it downloads at the default 720p instead. Downloading at 360p works normally however. This only appears to affect some videos (such as some others uploaded on this channel) and most videos are downloaded as expected at 144 or 240p 