### PR TITLE
[WIP] Tor support + FixTweet support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # os stuff
-.DS_Store
-desktop.ini
+**/.DS_Store
+**/desktop.ini
 
 # npm
 node_modules
@@ -24,3 +24,6 @@ docker-compose.yml
 
 # cookie file
 cookies.json
+
+# tor
+tor

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "esbuild": "^0.14.51",
         "express": "^4.18.1",
         "express-rate-limit": "^6.3.0",
+        "fetch-socks": "^1.2.0",
         "ffmpeg-static": "^5.1.0",
         "hls-parser": "^0.10.7",
         "nanoid": "^4.0.2",

--- a/src/cobalt.js
+++ b/src/cobalt.js
@@ -1,7 +1,8 @@
 import "dotenv/config";
 
 import express from "express";
-
+import { setGlobalDispatcher } from "undici";
+import { socksDispatcher } from "fetch-socks";
 import { Bright, Green, Red } from "./modules/sub/consoleText.js";
 import { getCurrentBranch, shortCommit } from "./modules/sub/currentCommit.js";
 import { loadLoc } from "./localization/manager.js";
@@ -21,8 +22,31 @@ app.disable('x-powered-by');
 
 await loadLoc();
 
-const apiMode = process.env.apiURL && process.env.apiPort && !((process.env.webURL && process.env.webPort) || (process.env.selfURL && process.env.port));
-const webMode = process.env.webURL && process.env.webPort && !((process.env.apiURL && process.env.apiPort) || (process.env.selfURL && process.env.port));
+const torEnabled = (process.env.torHost && process.env.torPort && true) ? true : false;
+const torGlobal = (process.env.torGlobal && process.env.torGlobal == "true") ? true : false;
+global.torEnabled = torEnabled;
+
+if (torEnabled) {
+    let torProxy = {
+        type: 5,
+        host: process.env.torHost,
+        port: Number(process.env.torPort)
+    }
+    let torOptions = {
+        connect: {
+            timeout: 30000
+        }
+    }
+    let twitterTorOptions = torOptions;
+    twitterTorOptions['connect']['rejectUnauthorized'] = false;
+
+    global.torDispatcher = socksDispatcher(torProxy, torOptions)
+    global.twitterTorDispatcher = socksDispatcher(torProxy, twitterTorOptions)
+    if (torGlobal) setGlobalDispatcher(global.torDispatcher)
+}
+
+const apiMode = (process.env.apiURL && process.env.apiPort && !((process.env.webURL && process.env.webPort) || (process.env.selfURL && process.env.port))) ? true : false;
+const webMode = (process.env.webURL && process.env.webPort && !((process.env.apiURL && process.env.apiPort) || (process.env.selfURL && process.env.port))) ? true : false;
 
 if (apiMode) {
     const { runAPI } = await import('./core/api.js');

--- a/src/core/api.js
+++ b/src/core/api.js
@@ -15,7 +15,7 @@ import { verifyStream } from "../modules/stream/manage.js";
 
 export function runAPI(express, app, gitCommit, gitBranch, __dirname) {
     const corsConfig = process.env.cors === '0' ? {
-        origin: process.env.webURL,
+        origin: [process.env.webURL, process.env.webOnion],
         optionsSuccessStatus: 200
     } : {};
 
@@ -49,6 +49,11 @@ export function runAPI(express, app, gitCommit, gitBranch, __dirname) {
     const startTime = new Date();
     const startTimestamp = Math.floor(startTime.getTime());
 
+    app.use((req, res, next) => {
+        if (global.torEnabled && process.env.apiOnion && !(req.hostname == process.env.apiOnion)) res.setHeader('Onion-Location', `${process.env.apiOnion}${req.path}`)
+        next();
+    });
+    
     app.use('/api/:type', cors(corsConfig));
     app.use('/api/json', apiLimiter);
     app.use('/api/stream', apiLimiterStream);

--- a/src/core/web.js
+++ b/src/core/web.js
@@ -14,6 +14,11 @@ export async function runWeb(express, app, gitCommit, gitBranch, __dirname) {
 
     await buildFront(gitCommit, gitBranch);
 
+    app.use((req, res, next) => {
+        if (global.torEnabled && process.env.webOnion && !(req.hostname == process.env.webOnion)) res.setHeader('Onion-Location', `${process.env.webOnion}${req.path}`)
+        next();
+    });
+
     app.use('/', express.static('./build/min'));
     app.use('/', express.static('./src/front'));
 

--- a/src/front/cobalt.js
+++ b/src/front/cobalt.js
@@ -344,9 +344,9 @@ function resetSettings() {
     localStorage.clear();
     window.location.reload();
 }
-if (window.location.hostname.endsWith(".onion")) document.getElementById('paste').style = "pointer-events:none;visibility:hidden;";
+if (window.location.hostname.endsWith(".onion") && !(navigator.getBattery())) document.getElementById('paste').style = "pointer-events:none;visibility:hidden;";
 async function pasteClipboard() {
-    if (window.location.hostname.endsWith(".onion")) return
+    if (window.location.hostname.endsWith(".onion") && !(navigator.getBattery())) return
     try {
         let t = await navigator.clipboard.readText();
         if (regex.test(t)) {
@@ -391,7 +391,7 @@ async function download(url) {
         if (url.includes("youtube.com/") || url.includes("/youtu.be/")) req.vCodec = sGet("vCodec").slice(0, 4);
         if ((url.includes("tiktok.com/") || url.includes("douyin.com/")) && sGet("disableTikTokWatermark") === "true") req.isNoTTWatermark = true;
     }
-    if (window.location.hostname.endsWith(".onion") && !(sGet("onionPreference") == "noOnions")) req.onionPreference = sGet("onionPreference")
+    if (window.location.hostname.endsWith(".onion") && !(sGet("onionPreference") == "noOnions")) req.onionPreference = sGet("onionPreference");
 
     if (sGet("disableMetadata") === "true") req.disableMetadata = true;
 

--- a/src/front/cobalt.js
+++ b/src/front/cobalt.js
@@ -18,7 +18,8 @@ const switchers = {
     "dubLang": ["original", "auto"],
     "vimeoDash": ["false", "true"],
     "audioMode": ["false", "true"],
-    "filenamePattern": ["classic", "pretty", "basic", "nerdy"]
+    "filenamePattern": ["classic", "pretty", "basic", "nerdy"],
+    "onionPreference": ["noOnions", "onionStrict", "clearnetFallback"]
 };
 const checkboxes = [
     "alwaysVisibleButton",
@@ -58,6 +59,14 @@ function sGet(id) {
 }
 function sSet(id, value) {
     localStorage.setItem(id, value)
+}
+if (sGet('onionPreference') == null) {
+    if (window.location.hostname.endsWith(".onion")) sSet("onionPreference", "clearnetFallback")
+    else sSet('onionPreference', 'noOnions');
+}
+if (!(window.location.hostname.endsWith(".onion"))) {
+    document.getElementById('settings-tor').style = 'display:none;';
+    if (!(sGet('onionPreference') === 'noOnions')) sSet("onionPreference", "noOnions");
 }
 function enable(id) {
     eid(id).dataset.enabled = "true";
@@ -131,6 +140,7 @@ function detectColorScheme() {
     } else if (!window.matchMedia) {
         theme = "dark"
     }
+    if (window.location.hostname.endsWith(".onion") && theme == "auto") theme = "dark";
     document.documentElement.setAttribute("data-theme", theme);
 }
 function changeTab(evnt, tabId, tabClass) {
@@ -334,7 +344,9 @@ function resetSettings() {
     localStorage.clear();
     window.location.reload();
 }
+if (window.location.hostname.endsWith(".onion")) document.getElementById('paste').style = "pointer-events:none;visibility:hidden;";
 async function pasteClipboard() {
+    if (window.location.hostname.endsWith(".onion")) return
     try {
         let t = await navigator.clipboard.readText();
         if (regex.test(t)) {
@@ -379,6 +391,7 @@ async function download(url) {
         if (url.includes("youtube.com/") || url.includes("/youtu.be/")) req.vCodec = sGet("vCodec").slice(0, 4);
         if ((url.includes("tiktok.com/") || url.includes("douyin.com/")) && sGet("disableTikTokWatermark") === "true") req.isNoTTWatermark = true;
     }
+    if (window.location.hostname.endsWith(".onion") && !(sGet("onionPreference") == "noOnions")) req.onionPreference = sGet("onionPreference")
 
     if (sGet("disableMetadata") === "true") req.disableMetadata = true;
 

--- a/src/localization/languages/en.json
+++ b/src/localization/languages/en.json
@@ -156,6 +156,11 @@
         "FilenamePreviewVideoTitle": "Video Title",
         "FilenamePreviewAudioTitle": "Audio Title",
         "FilenamePreviewAudioAuthor": "Audio Author",
+        "Tor": "tor",
+        "SettingsOnionStrict": "onions only",
+        "SettingsClearnetFallback": "prefer onions",
+        "SettingsNoOnions": "no onions",
+        "SettingsTorDescription": "onions only: strictly uses .onions throughout entire process except where already known to be required.\nprefer onions: uses .onions throughout entire process but will fallback to clearnet if cobalt can't connect.\nno onions: will only use clearnet throughout entire process.\n\nthis setting affects twitter and reddit.",
         "UrgentFilenameUpdate": "customizable file names!"
     }
 }

--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -14,7 +14,11 @@ export async function getJSON(originalURL, lang, obj) {
             hostname = new URL(url).hostname.split('.'),
             host = hostname[hostname.length - 2];
 
+        if (url.startsWith('http://')) url = url.replace('http://', 'https://');
         if (!url.startsWith('https://')) return apiJSON(0, { t: errorUnsupported(lang) });
+        if(url.startsWith("https://www.")) {
+            url = url.replace("https://www.", "https://")
+        }
 
         let overrides = hostOverrides(host, url);
         host = overrides.host;

--- a/src/modules/pageRender/page.js
+++ b/src/modules/pageRender/page.js
@@ -571,7 +571,7 @@ export default function(obj) {
                 <div id="logo">${t("AppTitleCobalt")}${betaTag()}</div>
                 <div id="download-area">
                     <div id="top">
-                        <input id="url-input-area" class="mono" type="text" autocorrect="off" maxlength="128" autocapitalize="off" placeholder="${t('LinkInput')}" aria-label="${t('AccessibilityInputArea')}" oninput="button()"></input>
+                        <input id="url-input-area" class="mono" type="text" autocorrect="off" maxlength="256" autocapitalize="off" placeholder="${t('LinkInput')}" aria-label="${t('AccessibilityInputArea')}" oninput="button()"></input>
                         <button id="url-clear" onclick="clearInput()" style="display:none;">x</button>
                         <input id="download-button" class="mono dontRead" onclick="download(document.getElementById('url-input-area').value)" type="submit" value="" disabled=true aria-label="${t('AccessibilityDownloadButton')}">
                     </div>

--- a/src/modules/pageRender/page.js
+++ b/src/modules/pageRender/page.js
@@ -38,6 +38,8 @@ export default function(obj) {
 
     audioFormats[0]["text"] = t('SettingsAudioFormatBest');
 
+    let onionLocation = (process.env.torHost && process.env.torPort && true) && process.env.webOnion ? `<meta http-equiv="onion-location" content="${process.env.webOnion}" />` : "";
+    
     try {
         return `
 <!DOCTYPE html>
@@ -49,6 +51,7 @@ export default function(obj) {
         <title>${t("AppTitleCobalt")}</title>
 
         <meta property="og:url" content="${process.env.webURL || process.env.selfURL}" />
+        ${onionLocation}
         <meta property="og:title" content="${t("AppTitleCobalt")}" />
         <meta property="og:description" content="${t('EmbedBriefDescription')}" />
         <meta property="og:image" content="${process.env.webURL || process.env.selfURL}icons/generic.png" />
@@ -497,6 +500,24 @@ export default function(obj) {
                         padding: "no-margin"
                     }])
                 })
+                + settingsCategory({
+                    name: "tor",
+                    title: t('Tor'),
+                    body: switcher({
+                        name: "onionPreference",
+                        items: [{
+                            action: "onionStrict",
+                            text: t('SettingsOnionStrict')
+                        }, {
+                            action: "clearnetFallback",
+                            text: t('SettingsClearnetFallback')
+                        }, {
+                            action: "noOnions",
+                            text: t('SettingsNoOnions')
+                        }]
+                    })
+                    + explanation(t('SettingsTorDescription'))
+                })
             }]
         })}
         ${popupWithBottomButtons({
@@ -613,7 +634,11 @@ export default function(obj) {
         </div>
     </body>
     <script type="text/javascript">
-        let defaultApiUrl = '${process.env.apiURL ? process.env.apiURL : ''}';
+        let defaultApiUrl;
+        let regularApiUrl = '${process.env.apiURL ? process.env.apiURL : ''}';
+        let onionApiUrl = '${process.env.apiOnion ? process.env.apiOnion : ''}';
+        defaultApiUrl = regularApiUrl;
+        if (window.location.hostname.endsWith('.onion')) defaultApiUrl = onionApiUrl;
         const loc = ${webLoc(t,
         [
             'ErrorNoInternet',

--- a/src/modules/processing/hostOverrides.js
+++ b/src/modules/processing/hostOverrides.js
@@ -3,30 +3,10 @@ export default function (inHost, inURL) {
     let url = String(inURL);
 
     switch(host) {
-        case "youtube":
-            if (url.startsWith("https://youtube.com/live/") || url.startsWith("https://www.youtube.com/live/")) {
-                url = url.split("?")[0].replace("www.", "");
-                url = `https://youtube.com/watch?v=${url.replace("https://youtube.com/live/", "")}`
-            }
-            if (url.includes('youtube.com/shorts/')) {
-                url = url.split('?')[0].replace('shorts/', 'watch?v=');
-            }
-            break;
-        case "youtu":
-            if (url.startsWith("https://youtu.be/")) {
-                host = "youtube";
-                url = `https://youtube.com/watch?v=${url.replace("https://youtu.be/", "")}`
-            }
-            break;
-        case "vxtwitter":
-        case "x":
-            if (url.startsWith("https://x.com/")) {
-                host = "twitter";
-                url = url.replace("https://x.com/", "https://twitter.com/")
-            }
-            if (url.startsWith("https://vxtwitter.com/")) {
-                host = "twitter";
-                url = url.replace("https://vxtwitter.com/", "https://twitter.com/")
+        case "reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad":
+            if (url.startsWith("https://reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion/")) {
+                host = "reddit";
+                url = url.replace("https://reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion/", "https://reddit.com/")
             }
             break;
         case "tumblr":
@@ -36,8 +16,70 @@ export default function (inHost, inURL) {
             }
             break;
         case "twitch":
-            if (url.includes('clips.twitch.tv')) {
+            if (url.startsWith("https://clips.twitch.tv")) {
                 url = url.split('?')[0].replace('clips.twitch.tv/', 'twitch.tv/_/clip/');
+            }
+            break;
+        case "vxtwitter":
+        case "fixvx":
+        case "fxtwitter":
+        case "twittpr":
+        case "fixupx":
+        case "x":
+        case "twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid":
+            if (url.startsWith("https://vxtwitter.com/")) {
+                host = "twitter";
+                url = url.replace("https://vxtwitter.com/", "https://twitter.com/")
+            }
+            if (url.startsWith("https://fixvx.com/")) {
+                host = "twitter";
+                url = url.replace("https://fixvx.com/", "https://twitter.com/")
+            }
+            if (url.startsWith("https://fxtwitter.com/")) {
+                host = "twitter";
+                url = url.replace("https://fxtwitter.com/", "https://twitter.com/")
+            }
+            if (url.startsWith("https://d.fxtwitter.com/")) {
+                host = "twitter";
+                url = url.replace("https://d.fxtwitter.com/", "https://twitter.com/")
+            }
+            if (url.startsWith("https://twittpr.com/")) {
+                host = "twitter";
+                url = url.replace("https://twittpr.com/", "https://twitter.com/")
+            }
+            if (url.startsWith("https://d.twittpr.com/")) {
+                host = "twitter";
+                url = url.replace("https://d.twittpr.com/", "https://twitter.com/")
+            }
+            if (url.startsWith("https://fixupx.com/")) {
+                host = "twitter";
+                url = url.replace("https://fixupx.com/", "https://twitter.com/")
+            }
+            if (url.startsWith("https://d.fixupx.com/")) {
+                host = "twitter";
+                url = url.replace("https://d.fixupx.com/", "https://twitter.com/")
+            }
+            if (url.startsWith("https://x.com/")) {
+                host = "twitter";
+                url = url.replace("https://x.com/", "https://twitter.com/")
+            }
+            if (url.startsWith("https://twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion/")) {
+                host = "twitter";
+                url = url.replace("https://twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion/", "https://twitter.com/")
+            }
+            break;
+        case "youtube":
+            if (url.startsWith("https://youtube.com/live/")) {
+                url = `https://youtube.com/watch?v=${url.split("?")[0].replace("https://youtube.com/live/", "")}`
+            }
+            if (url.startsWith("https://youtube.com/shorts/")) {
+                url = url.split('?')[0].replace('shorts/', 'watch?v=');
+            }
+            break;
+        case "youtu":
+            if (url.startsWith("https://youtu.be/")) {
+                host = "youtube";
+                url = `https://youtube.com/watch?v=${url.replace("https://youtu.be/", "")}`
             }
             break;
     }

--- a/src/modules/processing/matchActionDecider.js
+++ b/src/modules/processing/matchActionDecider.js
@@ -44,6 +44,10 @@ export default function(r, host, audioFormat, isAudioOnly, lang, isAudioMuted, d
                     params = { type: r.type };
                     break;
                 case "reddit":
+                    // ffmpeg doesn't support SOCKS5 proxies, which is necessary to use tor.
+                    // ffmpeg won't be able to resolve the .onion address, so we need to
+                    // change it back to the clearnet counterpart
+                    r.urls.forEach((url, index) => { r.urls[index] = url.replace('redditdotzhmh3mao6r5i2j7speppwqkizwo7vksy3mbz5iz7rlhocyd.onion', 'redd.it') });
                     responseType = r.typeId;
                     params = { type: r.type };
                     break;

--- a/src/modules/processing/services/reddit.js
+++ b/src/modules/processing/services/reddit.js
@@ -22,6 +22,9 @@ async function getAccessToken() {
                         || Number(values.expiry) > new Date().getTime();
     if (!needRefresh) return values.access_token;
 
+    let redditURL = "reddit.com";
+    if (global.torEnabled) redditURL = "reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion";
+
     const data = await fetch(`https://www.${redditURL}/api/v1/access_token`, {
         method: 'POST',
         headers: {
@@ -49,11 +52,8 @@ async function getAccessToken() {
 }
 
 export default async function(obj) {
-    let redditURL;
-    let regularURL = "reddit.com";
-    let torURL = "reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion";
-    redditURL = regularURL;
-    if (global.torEnabled) redditURL = torURL;
+    let redditURL = "reddit.com";
+    if (global.torEnabled) redditURL = "reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion";
 
     let twitterDispatcher;
     twitterDispatcher = false;

--- a/src/modules/processing/services/reddit.js
+++ b/src/modules/processing/services/reddit.js
@@ -52,8 +52,8 @@ export default async function(obj) {
     let redditURL;
     let regularURL = "reddit.com";
     let torURL = "reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion";
-    if (torEnabled) redditURL = torURL
-    else redditURL = regularURL;
+    redditURL = regularURL;
+    if (global.torEnabled) redditURL = torURL;
 
     let twitterDispatcher;
     twitterDispatcher = false;

--- a/src/modules/processing/services/twitter.js
+++ b/src/modules/processing/services/twitter.js
@@ -1,6 +1,5 @@
 import { fetch, getGlobalDispatcher } from "undici";
 import { genericUserAgent } from "../../config.js";
-import { socksDispatcher } from "fetch-socks";
 
 function bestQuality(arr) {
     return arr.filter(v => v["content_type"] === "video/mp4").sort((a, b) => Number(b.bitrate) - Number(a.bitrate))[0]["url"]

--- a/src/modules/processing/services/twitter.js
+++ b/src/modules/processing/services/twitter.js
@@ -9,8 +9,8 @@ export default async function(obj) {
     let twitterURL;
     let regularURL = "twitter.com";
     let torURL = "twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion";
-    if (torEnabled) twitterURL = torURL
-    else twitterURL = regularURL;
+    twitterURL = regularURL;
+    if (global.torEnabled) twitterURL = torURL;
 
     let twitterDispatcher;
     twitterDispatcher = false;
@@ -35,7 +35,7 @@ export default async function(obj) {
         dispatcher: twitterDispatcher,
         method: "POST",
         headers: _headers
-    }).then((r) => { return r.status === 200 ? r.json() : false }).catch((err) => { return false });
+    }).then((r) => { return r.status === 200 ? r.json() : false }).catch(() => { return false });
     if (!req_act) return { error: 'ErrorCouldntFetch' };
 
     _headers["host"] = twitterURL;

--- a/src/modules/processing/services/twitter.js
+++ b/src/modules/processing/services/twitter.js
@@ -6,11 +6,8 @@ function bestQuality(arr) {
 }
 
 export default async function(obj) {
-    let twitterURL;
-    let regularURL = "twitter.com";
-    let torURL = "twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion";
-    twitterURL = regularURL;
-    if (global.torEnabled) twitterURL = torURL;
+    let twitterURL = "twitter.com";
+    if (global.torEnabled) twitterURL = "twitter3e4tixl4xyajtrzo62zg5vztmjuricljdp2c5kshju4avyoid.onion";
 
     let twitterDispatcher;
     twitterDispatcher = false;

--- a/src/modules/setup.js
+++ b/src/modules/setup.js
@@ -44,6 +44,7 @@ function setup() {
                     ob['apiURL'] = `http://localhost:9000/`;
                     ob['apiPort'] = 9000;
                     if (apiURL && apiURL !== "localhost") ob['apiURL'] = `https://${apiURL.toLowerCase()}/`;
+                    if (apiURL && apiURL.endsWith('.onion/')) ob['apiURL'] = apiURL.replace('https://', 'http://');
 
                     console.log(Bright("\nGreat! Now, what port will it be running on? (9000)"));
 


### PR DESCRIPTION
work for #231.

this **currently WIP** pull request makes a few changes **currently**:
* accessing cobalt *from a .onion hostname* in a browser detected to be Firefox will hide the "paste from clipboard" option to discourage Tor users from changing settings that may decrease their security / increase their fingerprintability
* .onion links for Twitter/Reddit now work in the URL textbox
* The BetterTwitFix link `fixvx.com` now works in the URL textbox
* all FixTweet links now work in the URL textbox
* the maximum length of the textbox has been increased to 256, mainly to accommodate for allowing the very long (and maybe longer in the future) .onion links
* host overrides have been organized alphabetically
* [actively working on Tor support, so there will probably be more changes]

this PR is best done squashed I think but I can also re-commit these and make it properly named instead of being as it is right now