### PR TITLE
feat: add filename attributes to twitch clips

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ this list is not final and keeps expanding over time. if support for a service y
 | streamable                     | ✅            | ✅         | ✅         | ➖         | ➖              |
 | tiktok                         | ✅            | ✅         | ✅         | ❌         | ❌              |
 | tumblr                         | ✅            | ✅         | ✅         | ➖         | ➖              |
-| twitch clips                   | ✅            | ✅         | ✅         | ✅         | ❌              |
+| twitch clips                   | ✅            | ✅         | ✅         | ✅         | ✅              |
 | twitter/x                      | ✅            | ✅         | ✅         | ➖         | ➖              |
 | vimeo                          | ✅            | ✅         | ✅         | ✅         | ✅              |
 | vine archive                   | ✅            | ✅         | ✅         | ➖         | ➖              |

--- a/src/modules/processing/services/twitch.js
+++ b/src/modules/processing/services/twitch.js
@@ -1,4 +1,5 @@
 import { maxVideoDuration } from "../../config.js";
+import { cleanString } from '../../sub/utils.js';
 
 const gqlURL = "https://gql.twitch.tv/gql";
 const clientIdHead = { "client-id": "kimne78kx3ncx6brgo4mv6wki5h1ko" };

--- a/src/modules/processing/services/twitch.js
+++ b/src/modules/processing/services/twitch.js
@@ -19,6 +19,7 @@ export default async function (obj) {
                 }
                 durationSeconds
                 id
+                slug
                 medium: thumbnailURL(width: 480, height: 272)
                 title
                 videoQualities {
@@ -69,6 +70,13 @@ export default async function (obj) {
         fileMetadata: {
             title: clipMetadata.title,
             artist: `Twitch Clip by @${clipMetadata.broadcaster.login}, clipped by @${clipMetadata.curator.login}`,
+        },
+        filenameAttributes: {
+            service: "twitch",
+            id: clipMetadata.id,
+            title: fileMetadata.title,
+            author: `${clipMetadata.broadcaster.login}, clipped by ${clipMetadata.curator.login}`,
+            qualityLabel: `${format.quality}p`
         },
         filename: `twitchclip_${clipMetadata.id}_${format.quality}p.mp4`,
         audioFilename: `twitchclip_${clipMetadata.id}_audio`

--- a/src/modules/processing/services/twitch.js
+++ b/src/modules/processing/services/twitch.js
@@ -67,13 +67,13 @@ export default async function (obj) {
             token: req_token[0].data.clip.playbackAccessToken.value
         })}`,
         fileMetadata: {
-            title: clipMetadata.title,
+            title: cleanString(clipMetadata.title.trim()),
             artist: `Twitch Clip by @${clipMetadata.broadcaster.login}, clipped by @${clipMetadata.curator.login}`,
         },
         filenameAttributes: {
             service: "twitch",
             id: clipMetadata.id,
-            title: clipMetadata.title,
+            title: cleanString(clipMetadata.title.trim()),
             author: `${clipMetadata.broadcaster.login}, clipped by ${clipMetadata.curator.login}`,
             qualityLabel: `${format.quality}p`,
             extension: 'mp4'

--- a/src/modules/processing/services/twitch.js
+++ b/src/modules/processing/services/twitch.js
@@ -19,7 +19,6 @@ export default async function (obj) {
                 }
                 durationSeconds
                 id
-                slug
                 medium: thumbnailURL(width: 480, height: 272)
                 title
                 videoQualities {
@@ -74,7 +73,7 @@ export default async function (obj) {
         filenameAttributes: {
             service: "twitch",
             id: clipMetadata.id,
-            title: fileMetadata.title,
+            title: clipMetadata.title,
             author: `${clipMetadata.broadcaster.login}, clipped by ${clipMetadata.curator.login}`,
             qualityLabel: `${format.quality}p`
         },

--- a/src/modules/processing/services/twitch.js
+++ b/src/modules/processing/services/twitch.js
@@ -75,7 +75,8 @@ export default async function (obj) {
             id: clipMetadata.id,
             title: clipMetadata.title,
             author: `${clipMetadata.broadcaster.login}, clipped by ${clipMetadata.curator.login}`,
-            qualityLabel: `${format.quality}p`
+            qualityLabel: `${format.quality}p`,
+            extension: 'mp4'
         },
         filename: `twitchclip_${clipMetadata.id}_${format.quality}p.mp4`,
         audioFilename: `twitchclip_${clipMetadata.id}_audio`


### PR DESCRIPTION
Would be good for twitch clips to use their titles, so this should work fine.

I could also do tiktok but I might have to remove hashtags for that.