### PR TITLE
add toggle for new domain popup

### DIFF
--- a/src/front/cobalt.js
+++ b/src/front/cobalt.js
@@ -30,6 +30,7 @@ const checkboxes = [
     "reduceTransparency",
     "disableAnimations",
     "disableMetadata",
+    "disableNewDomainPopup"
 ];
 const exceptions = { // used for mobile devices
     "vQuality": "720"
@@ -605,7 +606,9 @@ window.onload = () => {
         }
         loadSettings();
         detectColorScheme();
-        popup("migration", 1);
+
+        if(sGet("disableNewDomainPopup") !== "true")
+            popup("migration", 1);
     }
     window.history.replaceState(null, '', window.location.pathname);
 

--- a/src/localization/languages/en.json
+++ b/src/localization/languages/en.json
@@ -156,6 +156,7 @@
         "FilenamePreviewVideoTitle": "Video Title",
         "FilenamePreviewAudioTitle": "Audio Title",
         "FilenamePreviewAudioAuthor": "Audio Author",
-        "UrgentFilenameUpdate": "customizable file names!"
+        "UrgentFilenameUpdate": "customizable file names!",
+        "SettingsDisableNewDomainPopup": "disable new domain popup"
     }
 }

--- a/src/modules/pageRender/page.js
+++ b/src/modules/pageRender/page.js
@@ -494,6 +494,9 @@ export default function(obj) {
                     }, {
                         action: "disableChangelog",
                         name: t("SettingsDisableNotifications"),
+                    }, {
+                        action: "disableNewDomainPopup",
+                        name: t("SettingsDisableNewDomainPopup"),
                         padding: "no-margin"
                     }])
                 })


### PR DESCRIPTION
when trying to quickly use cobalt to download a video, often the browser's autocomplete can autocomplete the old domain and causes the new domain popup to show, which makes it slightly more annoying and slow to use cobalt due to the popup on screen. 

this pr adds a toggle to settings to disable the popup
<img width="607" alt="image" src="https://github.com/wukko/cobalt/assets/34780309/bfc3d3d7-d636-443e-94f1-1146625461f8">