### PR TITLE
fix robots.txt

### DIFF
--- a/src/front/robots.txt
+++ b/src/front/robots.txt
@@ -1,2 +1,5 @@
 User-Agent: *
-Disallow: /icons/ /fonts/ *.js *.css
+Disallow: /icons/
+Disallow: /fonts/
+Disallow: /*.js
+Disallow: /*.css


### PR DESCRIPTION
currently the robots.txt file is useless because it's interpreted as one path "/icons/ /fonts/ *.js *.css"

(an example path that would be accepted (and therefore disallowed on scrapers) by this regex would be `https://cobalt.tools/icons/ /fonts/ bla.js .css`, which is obviously nonsense & useless)