### PR TITLE
feat: input prefill with location hash

### DIFF
--- a/src/front/cobalt.js
+++ b/src/front/cobalt.js
@@ -607,9 +607,23 @@ window.onload = () => {
         detectColorScheme();
         popup("migration", 1);
     }
+
+    if (window.location.hash) {
+        const input = window.location.hash.slice(1);
+        eid("url-input-area").value = input;
+        button()
+    }
+
     window.history.replaceState(null, '', window.location.pathname);
 
     notificationCheck();
+}
+window.onhashchange = () => {
+    if (window.location.hash) {
+        const input = window.location.hash.slice(1);
+        eid("url-input-area").value = input;
+        button()
+    }
 }
 eid("url-input-area").addEventListener("keydown", (e) => {
     button();


### PR DESCRIPTION
Resolves #245 

# Summary

- On page load, check for hash in window location and update input with hash value if present.
  - NOTE: This doesn't implement the same value regex test that `?u=url` implementation does.

## Implementation drawbacks to consider

- If Cobalt happens to use hash values later on (i.e. navigating to an open settings page or specific point in changelog), this would need to be revised to handle those cases.