### PR TITLE
fix typo in api.md

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -19,19 +19,19 @@ Content-Type: application/json
 ```
 
 ### request body variables
-| key               | type      | variables                          | default   | description                                                                    |
-|:------------------|:----------|:-----------------------------------|:----------|:-------------------------------------------------------------------------------|
-| `url`             | `string`  | URL encoded as URI                 | `null`    | **must** be included in every request.                                         |
-| `vCodec`          | `string`  | `h264 / av1 / vp9`                 | `h264`    | applies only to youtube downloads. `h264` is recommended for phones.           |
-| `vQuality`        | `string`  | `144 / ... / 2160 / max`           | `720`     | `720` quality is recommended for phones.                                       |
-| `aFormat`         | `string`  | `best / mp3 / ogg / wav / opus`    | `mp3`     |                                                                                |
-| `filenamePattern` | `boolean` | `classic / pretty / basic / nerdy` | `classic` | changes the way files are named. previews can be seen in the web app.          |
-| `isAudioOnly`     | `boolean` | `true / false`                     | `false`   |                                                                                |
-| `isNoTTWatermark` | `boolean` | `true / false`                     | `false`   | changes whether downloaded tiktok videos have watermarks.                      |
-| `isTTFullAudio`   | `boolean` | `true / false`                     | `false`   | enables download of original sound used in a tiktok video.                     |
-| `isAudioMuted`    | `boolean` | `true / false`                     | `false`   | disables audio track in video downloads.                                       |
-| `dubLang`         | `boolean` | `true / false`                     | `false`   | backend uses Accept-Language hader for youtube video audio tracks when `true`. |
-| `disableMetadata` | `boolean` | `true / false`                     | `false`   | disables file metadata when set to `true`.                                     |
+| key               | type      | variables                          | default   | description                                                                     |
+|:------------------|:----------|:-----------------------------------|:----------|:--------------------------------------------------------------------------------|
+| `url`             | `string`  | URL encoded as URI                 | `null`    | **must** be included in every request.                                          |
+| `vCodec`          | `string`  | `h264 / av1 / vp9`                 | `h264`    | applies only to youtube downloads. `h264` is recommended for phones.            |
+| `vQuality`        | `string`  | `144 / ... / 2160 / max`           | `720`     | `720` quality is recommended for phones.                                        |
+| `aFormat`         | `string`  | `best / mp3 / ogg / wav / opus`    | `mp3`     |                                                                                 |
+| `filenamePattern` | `boolean` | `classic / pretty / basic / nerdy` | `classic` | changes the way files are named. previews can be seen in the web app.           |
+| `isAudioOnly`     | `boolean` | `true / false`                     | `false`   |                                                                                 |
+| `isNoTTWatermark` | `boolean` | `true / false`                     | `false`   | changes whether downloaded tiktok videos have watermarks.                       |
+| `isTTFullAudio`   | `boolean` | `true / false`                     | `false`   | enables download of original sound used in a tiktok video.                      |
+| `isAudioMuted`    | `boolean` | `true / false`                     | `false`   | disables audio track in video downloads.                                        |
+| `dubLang`         | `boolean` | `true / false`                     | `false`   | backend uses Accept-Language header for youtube video audio tracks when `true`. |
+| `disableMetadata` | `boolean` | `true / false`                     | `false`   | disables file metadata when set to `true`.                                      |
 
 ### response body variables
 | key          | type     | variables                                                   |


### PR DESCRIPTION
hader -> header

also, shouldn't filenamePattern be a string?