### PR TITLE
Support twitter.com mediaViewer URL

### DIFF
--- a/src/modules/processing/servicesConfig.json
+++ b/src/modules/processing/servicesConfig.json
@@ -15,7 +15,7 @@
             "alias": "twitter videos & voice",
             "altDomains": ["x.com", "vxtwitter.com", "fixvx.com"],
             "subdomains": ["mobile"],
-            "patterns": [":user/status/:id", ":user/status/:id/video/:v"],
+            "patterns": [":user/status/:id", ":user/status/:id/video/:v", ":user/status/:id/mediaViewer"],
             "enabled": true
         },
         "vk": {

--- a/src/modules/processing/servicesConfig.json
+++ b/src/modules/processing/servicesConfig.json
@@ -15,7 +15,7 @@
             "alias": "twitter videos & voice",
             "altDomains": ["x.com", "vxtwitter.com", "fixvx.com"],
             "subdomains": ["mobile"],
-            "patterns": [":user/status/:id", ":user/status/:id/video/:v", ":user/status/:id/mediaViewer"],
+            "patterns": [":user/status/:id", ":user/status/:id/video/:v"],
             "enabled": true
         },
         "vk": {

--- a/src/modules/processing/url.js
+++ b/src/modules/processing/url.js
@@ -34,6 +34,12 @@ export function aliasURL(url) {
             }
             break;
 
+        case "twitter":
+            if (url.pathname.toLowerCase().endsWith('/mediaviewer')) {
+                url = new URL(`https://twitter.com/${parts[1]}/${parts[2]}/${parts[3]}`);
+            }
+            break;
+
         case "twitch":
             if (url.hostname === 'clips.twitch.tv' && parts.length >= 2) {
                 url = new URL(`https://twitch.tv/_/clip/${parts[1]}`);

--- a/src/test/tests.json
+++ b/src/test/tests.json
@@ -12,6 +12,14 @@
             "status": "redirect"
         }
     }, {
+        "name": "video with mobile web mediaviewer",
+        "url": "https://twitter.com/XSpaces/status/1526955853743546372/mediaViewer?currentTweet=1526955853743546372&currentTweetUser=XSpaces&currentTweet=1526955853743546372&currentTweetUser=XSpaces",
+        "params": {},
+        "expected": {
+            "code": 200,
+            "status": "redirect"
+        }
+    }, {
         "name": "embedded twitter video",
         "url": "https://twitter.com/dustbin_nie/status/1624596567188717568?s=20",
         "params": {


### PR DESCRIPTION
This is the URL of the page on mobile web when you full-screen a video. Note: trying to visit a link this way will fail on desktop with "Hmm...this page doesn’t exist. Try searching for something else.", but will work if you simulate mobile web in your browser dev tools. Also the "mediaviewer" part isn't case-sensitive and the full URL has query-string params that aren't needed