### PR TITLE
cobalt.css: fix blurry text on modal contents

### DIFF
--- a/src/front/cobalt.css
+++ b/src/front/cobalt.css
@@ -966,7 +966,7 @@ button:active,
 }
 .popup,
 .scrollable #popup-content {
-    border-radius: 8px / 9px;
+    border-radius: 8px;
 }
 #popup-header .glass-bkg {
     border-top-left-radius: 8px 9px;


### PR DESCRIPTION
For some reason, chromium-based browsers show blurry contents inside `#popup-content` divs with a double valued border-radius. It doesn't happen on Firefox.

<details>
<summary>Screenshots</summary>

![Blurry content on Arc, before the fix](https://github.com/wukko/cobalt/assets/29630035/14f40861-19a6-4c04-842f-b08b79631aa4)
> (before, in prod)

---

![Regular rendering after the fix](https://github.com/wukko/cobalt/assets/29630035/dbc39513-51a4-42ba-bd60-c63d71f423a9)
> (after, with fix)

---

![Rendering fine on Firefox](https://github.com/wukko/cobalt/assets/29630035/981e5623-54bb-481c-abbd-b0f670df73b7)
> (firefox is fine)

</details>


Safari still renders blurry text, though this border-radius PR does not fix it.
The `translate` of the `transform` property from the `.center` class is the culprit, as you can see in the two screenshots below. This might need more time to fix, that's why I didn't look into it yet. This little PR will already fix this issue for most users though.

<details>
<summary>Screenshots</summary>

![Blurry text on Safari, in production](https://github.com/wukko/cobalt/assets/29630035/420298eb-1312-4da6-8340-a0a65c0b7d9a)

---

![After removing the `transform` property, the text isn't blurry anymore but the popup isn't centered](https://github.com/wukko/cobalt/assets/29630035/3955b177-49a1-40f0-8def-2065fd738217)

</details>