### PR TITLE
feat: epidemic sound support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ this list is not final and keeps expanding over time. if support for a service y
 | service                        | video + audio | only audio | only video | metadata | rich file names |
 | :--------                      | :-----------: | :--------: | :--------: | :------: | :-------------: |
 | bilibili.com                   | ✅            | ✅         | ✅         | ➖         | ➖              |
+| epidemic sound                 | ➖            | ✅         | ➖         | ✅         | ✅              |
 | instagram posts & stories      | ✅            | ✅         | ✅         | ➖         | ➖              |
 | instagram reels                | ✅            | ✅         | ✅         | ➖         | ➖              |
 | pinterest                      | ✅            | ✅         | ✅         | ➖         | ➖              |

--- a/src/modules/processing/match.js
+++ b/src/modules/processing/match.js
@@ -24,6 +24,7 @@ import pinterest from "./services/pinterest.js";
 import streamable from "./services/streamable.js";
 import twitch from "./services/twitch.js";
 import rutube from "./services/rutube.js";
+import epidemicsound from "./services/epidemicsound.js";
 
 export default async function(host, patternMatch, url, lang, obj) {
     assert(url instanceof URL);
@@ -156,6 +157,11 @@ export default async function(host, patternMatch, url, lang, obj) {
                     id: patternMatch.id,
                     quality: obj.vQuality,
                     isAudioOnly: isAudioOnly
+                });
+                break;
+            case "epidemicsound":
+                r = await epidemicsound({
+                    id: patternMatch.id
                 });
                 break;
             default:

--- a/src/modules/processing/services/epidemicsound.js
+++ b/src/modules/processing/services/epidemicsound.js
@@ -1,4 +1,4 @@
-export default async function (obj) {
+export default async function(obj) {
     let json = await fetch(`https://www.epidemicsound.com/json/track/${obj.id}`).then((r) => {
         return r.status === 200 ? r.json() : false
     }).catch(() => { return false });

--- a/src/modules/processing/services/epidemicsound.js
+++ b/src/modules/processing/services/epidemicsound.js
@@ -1,0 +1,22 @@
+export default async function (obj) {
+    let json = await fetch(`https://www.epidemicsound.com/json/track/${obj.id}`).then((r) => {
+        return r.status === 200 ? r.json() : false
+    }).catch(() => { return false });
+
+    let fileMetadata = {
+        title: json.title,
+        artist: (json.creatives.mainArtists || []).map(artist => artist.name).join(", ")
+    }
+
+    return {
+        urls: json.stems.full.lqMp3Url,
+        filenameAttributes: {
+            service: "epidemicsound",
+            id: json.id,
+            title: fileMetadata.title,
+            author: fileMetadata.artist
+        },
+        isMp3: true,
+        fileMetadata
+    }
+}

--- a/src/modules/processing/servicesConfig.json
+++ b/src/modules/processing/servicesConfig.json
@@ -106,6 +106,11 @@
             "tld": "ru",
             "patterns": ["video/:id", "play/embed/:id"],
             "enabled": true
+        },
+        "epidemicsound": {
+            "alias": "epidemic sound music and sound effects",
+            "patterns": ["track/:id"],
+            "enabled": true
         }
     }
 }

--- a/src/modules/processing/servicesPatternTesters.js
+++ b/src/modules/processing/servicesPatternTesters.js
@@ -2,10 +2,13 @@ export const testers = {
     "bilibili": (patternMatch) =>
         patternMatch.id?.length <= 12,
 
+    "epidemicsound": (patternMatch) =>
+        patternMatch.id?.length === 10,
+
     "instagram": (patternMatch) =>
         patternMatch.postId?.length <= 12
         || (patternMatch.username?.length <= 30 && patternMatch.storyId?.length <= 24),
-    
+
     "ok": (patternMatch) =>
         patternMatch.id?.length <= 16,
 
@@ -19,12 +22,12 @@ export const testers = {
         patternMatch.id?.length === 32,
 
     "soundcloud": (patternMatch) =>
-        (patternMatch.author?.length <= 255 && patternMatch.song?.length <= 255) 
+        (patternMatch.author?.length <= 255 && patternMatch.song?.length <= 255)
         || patternMatch.shortLink?.length <= 32,
 
     "streamable": (patternMatch) =>
         patternMatch.id?.length === 6,
-    
+
     "tiktok": (patternMatch) =>
         patternMatch.postId?.length <= 21 || patternMatch.id?.length <= 13,
 

--- a/src/test/tests.json
+++ b/src/test/tests.json
@@ -1171,5 +1171,14 @@
             "code": 200,
             "status": "stream"
         }
+    }],
+    "epidemicsound": [{
+        "name": "track",
+        "url": "https://www.epidemicsound.com/track/NpuE3YgGmN/",
+        "params": {},
+        "expected": {
+            "code": 200,
+            "status": "stream"
+        }
     }]
 }


### PR DESCRIPTION
Added support for Epidemic Sound. Tests pass.

You can try this on any track link. To find some track links, here is an example page: https://www.epidemicsound.com/music/genres/electronic/