### PR TITLE
feat: bandcamp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ this list is not final and keeps expanding over time. if support for a service y
 
 | service                        | video + audio | only audio | only video | metadata | rich file names |
 | :--------                      | :-----------: | :--------: | :--------: | :------: | :-------------: |
+| bandcamp                       | ➖            | ✅         | ➖         | ✅         | ✅              |
 | bilibili.com                   | ✅            | ✅         | ✅         | ➖         | ➖              |
 | instagram posts & stories      | ✅            | ✅         | ✅         | ➖         | ➖              |
 | instagram reels                | ✅            | ✅         | ✅         | ➖         | ➖              |

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "express-rate-limit": "^6.3.0",
         "ffmpeg-static": "^5.1.0",
         "hls-parser": "^0.10.7",
+        "libxmljs": "^1.0.11",
         "nanoid": "^4.0.2",
         "node-cache": "^5.1.2",
         "psl": "1.9.0",

--- a/src/modules/processing/match.js
+++ b/src/modules/processing/match.js
@@ -24,6 +24,7 @@ import pinterest from "./services/pinterest.js";
 import streamable from "./services/streamable.js";
 import twitch from "./services/twitch.js";
 import rutube from "./services/rutube.js";
+import bandcamp from "./services/bandcamp.js";
 
 export default async function(host, patternMatch, url, lang, obj) {
     assert(url instanceof URL);
@@ -156,6 +157,12 @@ export default async function(host, patternMatch, url, lang, obj) {
                     id: patternMatch.id,
                     quality: obj.vQuality,
                     isAudioOnly: isAudioOnly
+                });
+                break;
+            case "bandcamp":
+                r = await bandcamp({
+                    url,
+                    name: patternMatch.name
                 });
                 break;
             default:

--- a/src/modules/processing/services/bandcamp.js
+++ b/src/modules/processing/services/bandcamp.js
@@ -1,0 +1,29 @@
+import libxmljs from "libxmljs";
+
+export default async function(obj) {
+    const htmlContent = await fetch(obj.url.href).then((r) => {
+        return r.status === 200 ? r.text() : false
+    }).catch(() => { return false });
+    const htmlDoc = await libxmljs.parseHtmlAsync(htmlContent)
+        .then((d) => { return d });
+    const rawData = htmlDoc.find("//script[@data-tralbum]")[0];
+    const json = JSON.parse(rawData.getAttribute("data-tralbum").value());
+
+    let fileMetadata = {
+        title: json.current.title,
+        artist: json.artist
+    }
+
+    return {
+        urls: json.trackinfo[0].file["mp3-128"],
+        filenameAttributes: {
+            service: "bandcamp",
+            id: json.trackinfo[0].id,
+            title: fileMetadata.title,
+            artist: fileMetadata.artist,
+            extension: "mp3"
+        },
+        isMp3: true,
+        fileMetadata
+    }
+}

--- a/src/modules/processing/servicesConfig.json
+++ b/src/modules/processing/servicesConfig.json
@@ -106,6 +106,12 @@
             "tld": "ru",
             "patterns": ["video/:id", "play/embed/:id"],
             "enabled": true
+        },
+        "bandcamp": {
+            "alias": "bandcamp music",
+            "patterns": ["track/:name"],
+            "subdomains": "*",
+            "enabled": true
         }
     }
 }

--- a/src/modules/processing/servicesPatternTesters.js
+++ b/src/modules/processing/servicesPatternTesters.js
@@ -1,11 +1,14 @@
 export const testers = {
+    "bandcamp": (patternMatch) =>
+        patternMatch.name?.length >= 0,
+
     "bilibili": (patternMatch) =>
         patternMatch.id?.length <= 12,
 
     "instagram": (patternMatch) =>
         patternMatch.postId?.length <= 12
         || (patternMatch.username?.length <= 30 && patternMatch.storyId?.length <= 24),
-    
+
     "ok": (patternMatch) =>
         patternMatch.id?.length <= 16,
 
@@ -19,12 +22,12 @@ export const testers = {
         patternMatch.id?.length === 32,
 
     "soundcloud": (patternMatch) =>
-        (patternMatch.author?.length <= 255 && patternMatch.song?.length <= 255) 
+        (patternMatch.author?.length <= 255 && patternMatch.song?.length <= 255)
         || patternMatch.shortLink?.length <= 32,
 
     "streamable": (patternMatch) =>
         patternMatch.id?.length === 6,
-    
+
     "tiktok": (patternMatch) =>
         patternMatch.postId?.length <= 21 || patternMatch.id?.length <= 13,
 

--- a/src/test/tests.json
+++ b/src/test/tests.json
@@ -1171,5 +1171,14 @@
             "code": 200,
             "status": "stream"
         }
+    }],
+    "bandcamp": [{
+        "name": "regular track",
+        "url": "https://home96.bandcamp.com/track/5",
+        "params": {},
+        "expected": {
+            "code": 200,
+            "status": "stream"
+        }
     }]
 }


### PR DESCRIPTION
Added support for Bandcamp. Tests pass.

This works on the tracks from any artist subdomain. Here is an example track link that works (this track is from an album that is already free to download):
https://home96.bandcamp.com/track/5