### PR TITLE
upgrate youtubei.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
         "set-cookie-parser": "2.6.0",
         "undici": "^5.19.1",
         "url-pattern": "1.0.3",
-        "youtubei.js": "^6.4.1"
+        "youtubei.js": "^9.1.0"
     }
 }


### PR DESCRIPTION
When I run this application within locally mode, an error occured when I wanted to download a youtube video.
<img width="946" alt="image" src="https://github.com/wukko/cobalt/assets/20265760/05569d20-a3a5-4b65-8286-257936e08462">

It worked well after upgrating the youtubei.js to recent vision, so I create this PR, hope to help others.