### PR TITLE
docs/api: add missing 'API_URL' to web

### DIFF
--- a/docs/run-an-instance.md
+++ b/docs/run-an-instance.md
@@ -67,6 +67,6 @@ sudo service nscd start
 |:--------------- |:--------|:------------------------|:--------------------------------------------------------------------------------------|
 | `WEB_PORT`      | `9001`  |  `9001`                 | changes port from which frontend server is accessible.                                |
 | `WEB_URL`       | ➖      | `https://cobalt.tools/` | changes url from which frontend server is accessible. <br> ***REQUIRED TO RUN WEB***. |
-| `API_URL`       | ➖      | `https://co.wuk.sh/`    | changes url from which api server is accessible.                                      |
+| `API_URL`       | ➖      | `https://co.wuk.sh/`    | changes url which is used for api requests by frontend clients.                       |
 | `SHOW_SPONSORS` | `0`     | `1`                     | toggles sponsor list in about popup. <br> `0`: disabled. `1`: enabled.                |
 | `IS_BETA`       | `0`     | `1`                     | toggles beta tag next to cobalt logo. <br> `0`: disabled. `1`: enabled.               |

--- a/docs/run-an-instance.md
+++ b/docs/run-an-instance.md
@@ -67,6 +67,6 @@ sudo service nscd start
 |:--------------- |:--------|:------------------------|:--------------------------------------------------------------------------------------|
 | `WEB_PORT`      | `9001`  |  `9001`                 | changes port from which frontend server is accessible.                                |
 | `WEB_URL`       | ➖      | `https://cobalt.tools/` | changes url from which frontend server is accessible. <br> ***REQUIRED TO RUN WEB***. |
-| `API_URL`       | ➖      | `https://co.wuk.sh/`    | changes url from which api server is accessible. |
+| `API_URL`       | ➖      | `https://co.wuk.sh/`    | changes url from which api server is accessible.                                      |
 | `SHOW_SPONSORS` | `0`     | `1`                     | toggles sponsor list in about popup. <br> `0`: disabled. `1`: enabled.                |
 | `IS_BETA`       | `0`     | `1`                     | toggles beta tag next to cobalt logo. <br> `0`: disabled. `1`: enabled.               |

--- a/docs/run-an-instance.md
+++ b/docs/run-an-instance.md
@@ -67,5 +67,6 @@ sudo service nscd start
 |:--------------- |:--------|:------------------------|:--------------------------------------------------------------------------------------|
 | `WEB_PORT`      | `9001`  |  `9001`                 | changes port from which frontend server is accessible.                                |
 | `WEB_URL`       | ➖      | `https://cobalt.tools/` | changes url from which frontend server is accessible. <br> ***REQUIRED TO RUN WEB***. |
+| `API_URL`       | ➖      | `https://co.wuk.sh/`    | changes url from which api server is accessible. |
 | `SHOW_SPONSORS` | `0`     | `1`                     | toggles sponsor list in about popup. <br> `0`: disabled. `1`: enabled.                |
 | `IS_BETA`       | `0`     | `1`                     | toggles beta tag next to cobalt logo. <br> `0`: disabled. `1`: enabled.               |

--- a/docs/run-an-instance.md
+++ b/docs/run-an-instance.md
@@ -63,10 +63,10 @@ sudo service nscd start
 \* the higher the nice value, the lower the priority. [read more here](https://en.wikipedia.org/wiki/Nice_(Unix)).
 
 ### variables for web
-| variable name   | default | example                 | description                                                                           |
-|:--------------- |:--------|:------------------------|:--------------------------------------------------------------------------------------|
-| `WEB_PORT`      | `9001`  |  `9001`                 | changes port from which frontend server is accessible.                                |
-| `WEB_URL`       | ➖      | `https://cobalt.tools/` | changes url from which frontend server is accessible. <br> ***REQUIRED TO RUN WEB***. |
-| `API_URL`       | ➖      | `https://co.wuk.sh/`    | changes url which is used for api requests by frontend clients.                       |
-| `SHOW_SPONSORS` | `0`     | `1`                     | toggles sponsor list in about popup. <br> `0`: disabled. `1`: enabled.                |
-| `IS_BETA`       | `0`     | `1`                     | toggles beta tag next to cobalt logo. <br> `0`: disabled. `1`: enabled.               |
+| variable name   | default              | example                 | description                                                                           |
+|:--------------- |:---------------------|:------------------------|:--------------------------------------------------------------------------------------|
+| `WEB_PORT`      | `9001`               |  `9001`                 | changes port from which frontend server is accessible.                                |
+| `WEB_URL`       | ➖                   | `https://cobalt.tools/` | changes url from which frontend server is accessible. <br> ***REQUIRED TO RUN WEB***. |
+| `API_URL`       | `https://co.wuk.sh/` | `https://co.wuk.sh/`    | changes url which is used for api requests by frontend clients.                       |
+| `SHOW_SPONSORS` | `0`                  | `1`                     | toggles sponsor list in about popup. <br> `0`: disabled. `1`: enabled.                |
+| `IS_BETA`       | `0`                  | `1`                     | toggles beta tag next to cobalt logo. <br> `0`: disabled. `1`: enabled.               |


### PR DESCRIPTION
Noticed this was missing when I was updating my environment variables.