### PR TITLE
docs/example/docker: Add COOKIE_PATH example to compose

### DIFF
--- a/docs/examples/docker-compose.example.yml
+++ b/docs/examples/docker-compose.example.yml
@@ -21,6 +21,8 @@ services:
             API_URL: "https://co.wuk.sh/"
             # replace eu-nl with your instance's distinctive name
             API_NAME: "eu-nl"
+            # if you want to use cookies when fetching data from services, uncomment the next line and the lines under volume
+            # COOKIE_PATH: "/cookies.json"
             # see docs/run-an-instance.md for more information
         labels:
             - com.centurylinklabs.watchtower.scope=cobalt


### PR DESCRIPTION
To prevent other people like me: https://github.com/wukko/cobalt/issues/435 from running into this if they rush into  deploying the compose file. 

> imo a COOKIE_PATH example should also be included in the compose file if a volume suggestion for it is offered, or alternatively, in the app try to read COOKIE_PATH and if it doesn't exist read /cookies.json. I didn't read the table at the bottom under the docker compose section and I actually found this out from cloning the source code and searching for cookie lol